### PR TITLE
Add the ability to match ordered XML

### DIFF
--- a/lib/rspec/xml_helpers.rb
+++ b/lib/rspec/xml_helpers.rb
@@ -10,7 +10,11 @@ module RSpec
   module XmlHelpers
     # @param [String<XML>] expected
     def match_xml(expected)
-      XmlMatcher.new(expected)
+      XmlMatcher.new(expected, ordered: false)
+    end
+
+    def match_ordered_xml(expected)
+      XmlMatcher.new(expected, ordered: true)
     end
 
     class << self
@@ -18,8 +22,8 @@ module RSpec
       # @param [String<XML>] xml
       # @return [String<XML>]
       # @api private
-      def normalize_xml(xml)
-        XmlFormatter.new.format(xml)
+      def normalize_xml(xml, ordered:)
+        XmlFormatter.new.format(xml, ordered: ordered)
       end
 
     end

--- a/lib/rspec/xml_helpers/xml_formatter.rb
+++ b/lib/rspec/xml_helpers/xml_formatter.rb
@@ -9,9 +9,9 @@ module RSpec
     # @api private
     class XmlFormatter
 
-      def format(xml)
+      def format(xml, ordered:)
         xml = NawsXml::Parser.new.parse(xml)
-        xml = stable_sort(xml)
+        xml = stable_sort(xml) unless ordered
         xml.to_s(indent: '  ')
       end
 

--- a/lib/rspec/xml_helpers/xml_matcher.rb
+++ b/lib/rspec/xml_helpers/xml_matcher.rb
@@ -25,16 +25,17 @@ module RSpec
           %<got>s
       MSG
 
-      def initialize(expected, colorize: true)
-        @expected = XmlHelpers.normalize_xml(expected)
+      def initialize(expected, ordered:, colorize: true)
+        @expected = XmlHelpers.normalize_xml(expected, ordered: ordered)
         @diff_format = colorize ? :color : :text
+        @ordered = ordered
       rescue NawsXml::ParseError => error
         raise ArgumentError, format(BAD_EXPECTED,
           error: error.message, got: got(expected))
       end
 
       def matches?(actual)
-        @actual = XmlHelpers.normalize_xml(actual)
+        @actual = XmlHelpers.normalize_xml(actual, ordered: @ordered)
         @expected == @actual
       rescue NawsXml::ParseError => error
         @error_message = format(BAD_ACTUAL,
@@ -68,7 +69,6 @@ module RSpec
         value = xml.inspect if value == ''
         value
       end
-
     end
   end
 end

--- a/spec/rspec/matches_xml_spec.rb
+++ b/spec/rspec/matches_xml_spec.rb
@@ -5,101 +5,224 @@ require_relative '../spec_helper'
 module RSpec
   module XmlHelpers
     describe XmlMatcher do
-      it 'matches XML strings' do
-        expect('<xml/>').to match_xml('<xml/>')
+      describe '#match_xml' do
+        it 'matches XML strings' do
+          expect('<xml/>').to match_xml('<xml/>')
+        end
+
+        it 'fails to matches different XML strings' do
+          expect('<xml/>').not_to match_xml('<xml atttr="value"/>')
+        end
+
+        it 'considers whitespace significant for elements without children' do
+          expect('<xml> </xml>').not_to match_xml('<xml/>')
+        end
+
+        it 'matches nested XML strings' do
+          expect('<xml><nested/></xml>').to match_xml('<xml><nested/></xml>')
+        end
+
+        it 'matches XML with attributes strings' do
+          expect('<xml><nested attr="value"/></xml>').to match_xml('<xml><nested attr="value"/></xml>')
+        end
+
+        it 'matches XML with text' do
+          expect('<xml><nested>value</nested></xml>').to match_xml('<xml><nested>value</nested></xml>')
+        end
+
+        it 'matches ignoring whitespace' do
+          expect('<xml><nested/></xml>').to match_xml(<<~XML)
+            <xml>
+              <nested/>
+            </xml>
+          XML
+        end
+
+        it 'ignores child node order' do
+          expect('<xml><child1/><child2/></xml>').to match_xml(<<~XML)
+            <xml>
+              <child2/>
+              <child1/>
+            </xml>
+          XML
+        end
+
+        it 'stable sorts children with the same name' do
+          actual = '<xml><c>1</c><c>2</c></xml>'
+          expected = '<xml><c>1</c><c>2</c></xml>'
+          expect(actual).to match_xml(expected)
+
+          actual = '<xml><c>2</c><c>1</c></xml>'
+          expected = '<xml><c>1</c><c>2</c></xml>'
+          expect(actual).not_to match_xml(expected)
+        end
+
+        it 'gives a helpful error message when xml does not match' do
+          actual = '<xml><node>value</node></xml>'
+          expected = '<xml><otherNode>value</otherNode></xml>'
+          matcher = XmlMatcher.new(expected, ordered: false, colorize: false)
+          matcher.matches?(actual)
+          expect(matcher.failure_message).to eq(<<~MSG)
+            Expected:
+
+            <xml>
+              <otherNode>value</otherNode>
+            </xml>
+
+            Got:
+
+            <xml>
+              <node>value</node>
+            </xml>
+
+            Diff:
+
+             <xml>
+            -  <otherNode>value</otherNode>
+            +  <node>value</node>
+          MSG
+        end
+
+        it 'gives a helpful error message when actual is not valid XML' do
+          expect do
+            expect(123).to match_xml('<xml/>')
+          end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
+            /^Expected actual to be an XML string, encountered error while parsing:.+123/m)
+        end
+
+        it 'gives a helpful error message when expected is not valid XML' do
+          expect do
+            expect('<xml/>').to match_xml('123')
+          end.to raise_error(ArgumentError,
+            /^Encountered an error parsing the match_xml expected value:.+123/m)
+        end
+
+        it 'gives an error when negation matching fails' do
+          expect do
+            expect('<xml/>').not_to match_xml('<xml/>')
+          end.to raise_error(RSpec::Expectations::ExpectationNotMetError, 'Expected XML value not to match.')
+        end
       end
 
-      it 'fails to matches different XML strings' do
-        expect('<xml/>').not_to match_xml('<xml atttr="value"/>')
-      end
+      describe '#match_ordered_xml' do
+        it 'matches XML strings' do
+          expect('<xml/>').to match_ordered_xml('<xml/>')
+        end
 
-      it 'considers whitespace significant for elements without children' do
-        expect('<xml> </xml>').not_to match_xml('<xml/>')
-      end
+        it 'fails to matches different XML strings' do
+          expect('<xml/>').not_to match_ordered_xml('<xml atttr="value"/>')
+        end
 
-      it 'matches nested XML strings' do
-        expect('<xml><nested/></xml>').to match_xml('<xml><nested/></xml>')
-      end
+        it 'considers whitespace significant for elements without children' do
+          expect('<xml> </xml>').not_to match_ordered_xml('<xml/>')
+        end
 
-      it 'matches XML with attributes strings' do
-        expect('<xml><nested attr="value"/></xml>').to match_xml('<xml><nested attr="value"/></xml>')
-      end
+        it 'matches nested XML strings' do
+          expect('<xml><nested/></xml>').to match_ordered_xml('<xml><nested/></xml>')
+        end
 
-      it 'matches XML with text' do
-        expect('<xml><nested>value</nested></xml>').to match_xml('<xml><nested>value</nested></xml>')
-      end
+        it 'matches XML with attributes strings' do
+          expect('<xml><nested attr="value"/></xml>').to match_ordered_xml('<xml><nested attr="value"/></xml>')
+        end
 
-      it 'matches ignoring whitespace' do
-        expect('<xml><nested/></xml>').to match_xml(<<~XML)
-          <xml>
-            <nested/>
-          </xml>
-        XML
-      end
+        it 'matches XML with text' do
+          expect('<xml><nested>value</nested></xml>').to match_ordered_xml('<xml><nested>value</nested></xml>')
+        end
 
-      it 'ignores child node order' do
-        expect('<xml><child1/><child2/></xml>').to match_xml(<<~XML)
-          <xml>
-            <child2/>
-            <child1/>
-          </xml>
-        XML
-      end
+        it 'matches ignoring whitespace' do
+          expect('<xml><nested/></xml>').to match_ordered_xml(<<~XML)
+            <xml>
+              <nested/>
+            </xml>
+          XML
+        end
 
-      it 'stable sorts children with the same name' do
-        actual = '<xml><c>1</c><c>2</c></xml>'
-        expected = '<xml><c>1</c><c>2</c></xml>'
-        expect(actual).to match_xml(expected)
+        it 'respects child node order' do
+          expect('<xml><child1/><child2/></xml>').not_to match_ordered_xml(<<~XML)
+            <xml>
+              <child2/>
+              <child1/>
+            </xml>
+          XML
+        end
 
-        actual = '<xml><c>2</c><c>1</c></xml>'
-        expected = '<xml><c>1</c><c>2</c></xml>'
-        expect(actual).not_to match_xml(expected)
-      end
+        it 'gives a helpful error message when xml does not match' do
+          actual = '<xml><node>value</node></xml>'
+          expected = '<xml><otherNode>value</otherNode></xml>'
+          matcher = XmlMatcher.new(expected, ordered: true, colorize: false)
+          matcher.matches?(actual)
+          expect(matcher.failure_message).to eq(<<~MSG)
+            Expected:
 
-      it 'gives a helpful error message when xml does not match' do
-        actual = '<xml><node>value</node></xml>'
-        expected = '<xml><otherNode>value</otherNode></xml>'
-        matcher = XmlMatcher.new(expected, colorize: false)
-        matcher.matches?(actual)
-        expect(matcher.failure_message).to eq(<<~MSG)
-          Expected:
+            <xml>
+              <otherNode>value</otherNode>
+            </xml>
 
-          <xml>
-            <otherNode>value</otherNode>
-          </xml>
+            Got:
 
-          Got:
+            <xml>
+              <node>value</node>
+            </xml>
 
-          <xml>
-            <node>value</node>
-          </xml>
+            Diff:
 
-          Diff:
+             <xml>
+            -  <otherNode>value</otherNode>
+            +  <node>value</node>
+          MSG
+        end
 
-           <xml>
-          -  <otherNode>value</otherNode>
-          +  <node>value</node>
-        MSG
-      end
+        it 'gives a helpful error message when xml does not match due to order' do
+          actual = '<xml><node2>value</node2><node1>value</node1><node3>value</node3></xml>'
+          expected = '<xml><node1>value</node1><node2>value</node2><node3>value</node3></xml>'
+          matcher = XmlMatcher.new(expected, ordered: true, colorize: false)
+          matcher.matches?(actual)
+          expect(matcher.failure_message).to eq(<<~MSG)
+            Expected:
 
-      it 'gives a helpful error message when actual is not valid XML' do
-        expect do
-          expect(123).to match_xml('<xml/>')
-        end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-          /^Expected actual to be an XML string, encountered error while parsing:.+123/m)
-      end
+            <xml>
+              <node1>value</node1>
+              <node2>value</node2>
+              <node3>value</node3>
+            </xml>
 
-      it 'gives a helpful error message when expected is not valid XML' do
-        expect do
-          expect('<xml/>').to match_xml('123')
-        end.to raise_error(ArgumentError,
-          /^Encountered an error parsing the match_xml expected value:.+123/m)
-      end
+            Got:
 
-      it 'gives an error when negation matching fails' do
-        expect do
-          expect('<xml/>').not_to match_xml('<xml/>')
-        end.to raise_error(RSpec::Expectations::ExpectationNotMetError, 'Expected XML value not to match.')
+            <xml>
+              <node2>value</node2>
+              <node1>value</node1>
+              <node3>value</node3>
+            </xml>
+
+            Diff:
+
+             <xml>
+            -  <node1>value</node1>
+               <node2>value</node2>
+            +  <node1>value</node1>
+               <node3>value</node3>
+          MSG
+        end
+
+        it 'gives a helpful error message when actual is not valid XML' do
+          expect do
+            expect(123).to match_ordered_xml('<xml/>')
+          end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
+                             /^Expected actual to be an XML string, encountered error while parsing:.+123/m)
+        end
+
+        it 'gives a helpful error message when expected is not valid XML' do
+          expect do
+            expect('<xml/>').to match_ordered_xml('123')
+          end.to raise_error(ArgumentError,
+                             /^Encountered an error parsing the match_xml expected value:.+123/m)
+        end
+
+        it 'gives an error when negation matching fails' do
+          expect do
+            expect('<xml/>').not_to match_ordered_xml('<xml/>')
+          end.to raise_error(RSpec::Expectations::ExpectationNotMetError, 'Expected XML value not to match.')
+        end
       end
     end
   end


### PR DESCRIPTION
Previously `match_xml` would sort the expected and actual XML using `stable_sort`. This prevents the ability to check XML where order matters, such as Twilio TwiML. 

Simply skipping the sort allows for checking ordered XML while using all existing functionality.